### PR TITLE
feat: add image modal with slider

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,21 +1,3 @@
 * {
   scroll-behavior: smooth;
 }
-
-ul.slick-dots {
-  position: absolute;
-  bottom: 10px;
-  left: 0;
-  right: 0;
-  text-align: center;
-}
-
-.slick-list {
-  height: auto !important;
-}
-
-.slick-slide img {
-  width: 100%;
-  height: auto;
-  max-height: 300px;
-}

--- a/src/pages/Catalog/components/ProductCard.tsx
+++ b/src/pages/Catalog/components/ProductCard.tsx
@@ -93,11 +93,14 @@ const ProductCard = ({ product, loading }: Props) => {
           <Typography variant='h6' sx={{ display: 'flex', gap: 1 }}>
             {price?.discounted ? (
               <Typography component='span' sx={{ textDecoration: 'line-through' }} color='text.secondary'>
-                ${price?.value?.centAmount / 100}
+                ${((price?.value?.centAmount ?? 0) / 100).toFixed(2)}
               </Typography>
             ) : null}
             <Typography component='span'>
-              ${price?.discounted ? price?.discounted?.value?.centAmount / 100 : price?.value?.centAmount ?? 0 / 100}
+              $
+              {price?.discounted
+                ? ((price.discounted.value.centAmount ?? 0) / 100).toFixed(2)
+                : ((price?.value?.centAmount ?? 0) / 100).toFixed(2)}
             </Typography>
           </Typography>
         </StyledCardContent>

--- a/src/pages/DetailedProduct/components/ImageSlider.tsx
+++ b/src/pages/DetailedProduct/components/ImageSlider.tsx
@@ -1,0 +1,95 @@
+import React, { MouseEventHandler } from 'react';
+import Slider from 'react-slick';
+import { Box } from '@mui/material';
+import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
+import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
+
+function NextArrow({ onClick }: { onClick?: MouseEventHandler<HTMLDivElement> }) {
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        position: 'absolute',
+        right: '0',
+        padding: '10px',
+        top: '50%',
+        transform: 'translateY(-50%)',
+        cursor: 'pointer',
+        zIndex: 1,
+      }}
+    >
+      <ArrowForwardIosIcon style={{ color: 'gray' }} />
+    </div>
+  );
+}
+
+function PrevArrow({ onClick }: { onClick?: MouseEventHandler<HTMLDivElement> }) {
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        position: 'absolute',
+        left: '0',
+        padding: '10px',
+        top: '50%',
+        transform: 'translateY(-50%)',
+        cursor: 'pointer',
+        zIndex: 1,
+      }}
+    >
+      <ArrowBackIosNewIcon style={{ color: 'gray' }} />
+    </div>
+  );
+}
+
+const settings = {
+  dots: true,
+  infinite: true,
+  speed: 500,
+  slidesToShow: 1,
+  slidesToScroll: 1,
+  nextArrow: <NextArrow />,
+  prevArrow: <PrevArrow />,
+  adaptiveHeight: true,
+  appendDots: (dots: React.ReactNode) => (
+    <div
+      style={{
+        position: 'absolute',
+        bottom: '10px',
+        width: '100%',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <ul style={{ margin: 0, padding: 0 }}> {dots} </ul>
+    </div>
+  ),
+};
+
+interface ImageSliderProps {
+  images: { url: string }[];
+  onImageClick?: (index: number) => void;
+  initialSlide?: number;
+  fullScreen?: boolean;
+}
+
+const ImageSlider: React.FC<ImageSliderProps> = ({ images, onImageClick, initialSlide = 0, fullScreen = false }) => (
+  <Slider {...settings} initialSlide={initialSlide}>
+    {images.length &&
+      images.map((image, index) => (
+        <Box
+          key={index}
+          component='img'
+          sx={{ width: '100%', height: fullScreen ? '100vh' : 400, objectFit: 'contain', cursor: 'pointer' }}
+          src={image.url}
+          alt={`Product Image ${index}`}
+          onClick={() => onImageClick && onImageClick(index)}
+        />
+      ))}
+  </Slider>
+);
+
+export default ImageSlider;

--- a/src/pages/User/index.tsx
+++ b/src/pages/User/index.tsx
@@ -85,7 +85,7 @@ const UserPage = () => {
   const [showNewPassword, setShowNewPassword] = useState(false);
   const [showConfirmNewPassword, setShowConfirmNewPassword] = useState(false);
 
-  const { data: userProfile, refetch } = useGetUserProfileQuery();
+  const { data: userProfile, refetch, isLoading } = useGetUserProfileQuery();
   const [updateUserProfile] = useUpdateUserProfileMutation();
   const [changePassword] = useChangePasswordMutation();
   const [login] = useLoginMutation();
@@ -696,13 +696,9 @@ const UserPage = () => {
       ]
     : [];
 
-  // if (isLoading) {
-  //   return (
-  //     <Box display='flex' justifyContent='center' alignItems='center' minHeight='100vh'>
-  //       <CircularProgress size={45} />
-  //     </Box>
-  //   );
-  // }
+  if (isLoading) {
+    return <div style={{ position: 'absolute', top: '50%', left: '50%' }}>Loading...</div>;
+  }
 
   return (
     <Container maxWidth='md' sx={{ padding: 2 }}>


### PR DESCRIPTION
1) Tasks:
[RSS-ECOMM-3_12](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint3/RSS-ECOMM-3_12.md)
[RSS-ECOMM-3_13](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint3/RSS-ECOMM-3_13.md)

2)  Screenshot:
![image](https://github.com/dm-mrtnvch/e-commerce-app/assets/69173041/beee6212-cc50-4bcf-b250-76cbf1f759c0)

- [x] The product image triggers a modal to open when it is clicked.
- [x] The modal displays an enlarged version of the product image.
- [x] There is a clear way for the user to close the modal.
- [x] The enlarged image modal includes a slider that displays all product images fetched from the API.
- [x] Users can navigate through the images using the slider controls.